### PR TITLE
add navigate to home page

### DIFF
--- a/src/modules/CartPage/components/Modal/Modal.tsx
+++ b/src/modules/CartPage/components/Modal/Modal.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useNavigate } from 'react-router';
 import cn from 'classnames';
 import { useAppDispatch, useAppSelector } from '../../../../store/hooks';
 import { actions as cartActions } from '../../../../store/reducers/cartSlice';
@@ -16,6 +17,7 @@ export const Modal: React.FC<Props> = ({
 }) => {
   const dispatch = useAppDispatch();
   const { isDarkTheme } = useAppSelector((state) => state.theme);
+  const navigate = useNavigate();
 
   if (!isOpen) {
     return null;
@@ -24,6 +26,7 @@ export const Modal: React.FC<Props> = ({
   const clearCartHandler = () => {
     dispatch(cartActions.clear());
     onClose();
+    navigate('/');
   };
 
   return (


### PR DESCRIPTION
I noticed out tasks requaried to redirect to home page after we show modal window. I added this logic when we click yes we clear cart, close modal(we alreade had these) and redirect to home page